### PR TITLE
Fix 404 when clicking on email links

### DIFF
--- a/docs/conf/na/2015.md
+++ b/docs/conf/na/2015.md
@@ -42,11 +42,11 @@ If you are paying for yourself, work at a non-profit, or at a company with less 
 
 If you are currently enrolled as a student, or don't currently have a source of income.
 
-* $75 Student or Unemployed Tickets 
+* $75 Student or Unemployed Tickets
 
-#### Financial Assistance 
+#### Financial Assistance
 
-If you can't afford these prices and still wish to attend, please email us at [conf@writethedocs.org](conf@writethedocs.org) and we can work something out.
+If you can't afford these prices and still wish to attend, please email us at [conf@writethedocs.org][conf-email] and we can work something out.
 
 ## Events
 
@@ -101,15 +101,16 @@ If you wish to receive more information as it becomes available, follow us on Tw
 ## Sponsors
 
 We are seeking corporate partners to help us create the best conference possible.
-Contact us at [sponsorships@writethedocs.org](sponsorships@writethedocs.org) for more information on sponsoring Write the Docs.
+Contact us at [sponsorships@writethedocs.org][sponsorships] for more information on sponsoring Write the Docs.
 
 ## Contact Us
 
-Reach us by email at [conf@writethedocs.org](conf@writethedocs.org) if you have any questions or concerns.
+Reach us by email at [conf@writethedocs.org][conf-email] if you have any questions or concerns.
 
 
 [crystal-ballroom]: http://www.mcmenamins.com/CrystalBallroom
 [wabisabi]: http://en.wikipedia.org/wiki/Wabi-sabi
 [twitter]: https://twitter.com/writethedocs
 [mailing-list]: http://eepurl.com/I37rP
-
+[sponsorships]: mailto:sponsorships@writethedocs.org
+[conf-email]: mailto:conf@writethedocs.org


### PR DESCRIPTION
The email links on the conference page did not have a `mailto:`
prefix, which meant opening them in a browser navigates to
http://www.writethedocs.org/conf@writethedocs.org, which 404's. Fixes this by
appending `mailto:` to each link.

I checked the rest of this repo for the same problem and these were the only
instances I could find.
