### PR TITLE
Rewrite the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,8 @@
 ## Write the Docs website
 
-This is the code that powers www.writethedocs.org. It will contain information
-about Write the Docs as a group, as well as information about writing
-documentation.
+This is the code that powers [www.writethedocs.org](www.writethedocs.org). It contains information
+about the Write the Docs group, as well as information about writing documentation.
 
-The repo is still in it's early stages, but feel free to contribute information
-that you might want to share with the community.
+The repo is still in its early stages; feel free to contribute information that you might want to share with the community. To contribute to the Write the Docs website, famililarize yourself with the [Markdown site generator ``mkdocs``](http://www.mkdocs.org). The Write the Docs website is hosted on [Read the Docs](https://readthedocs.org/projects/writethedocs-www).
 
-#### How to use
-
-This website uses ``mkdocs``, which is a Markdown site generator: http://www.mkdocs.org/
-
-It is hosted on Read the Docs: https://readthedocs.org/projects/writethedocs-www/
-
-We do development in a dev branch, which is rendered here: http://writethedocs-www.readthedocs.org/en/dev/
-
-And production lives here: http://www.writethedocs.org/
+We development documentation on a `dev` branch, which is rendered at http://writethedocs-www.readthedocs.org/en/dev/.

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ about the Write the Docs group, as well as information about writing documentati
 
 The repo is still in its early stages; feel free to contribute information that you might want to share with the community. To contribute to the Write the Docs website, famililarize yourself with the [Markdown site generator ``mkdocs``](http://www.mkdocs.org). The Write the Docs website is hosted on [Read the Docs](https://readthedocs.org/projects/writethedocs-www).
 
-We development documentation on a `dev` branch, which is rendered at http://writethedocs-www.readthedocs.org/en/dev/.
+We develop documentation on a `dev` branch, which is rendered at http://writethedocs-www.readthedocs.org/en/dev/.


### PR DESCRIPTION
- Remove extraneous header "How to use" that does not contain a direct object (the website? the repo? the dev branch?)
- Remove verbose URLs because users are accustomed to hover or open links in a new window.
- Tighten up several phrases, and remove extraneous colons and an instance of "here" for accessibility reasons.
