### PR TITLE
Get rid of the warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 This is the code that powers [www.writethedocs.org](http://www.writethedocs.org). It contains information
 about the Write the Docs group, as well as information about writing documentation.
 
-The repo is still in its early stages; feel free to contribute information that you might want to share with the community. To contribute to the Write the Docs website, famililarize yourself with the [Markdown site generator ``mkdocs``](http://www.mkdocs.org). The Write the Docs website is hosted on [Read the Docs](https://readthedocs.org/projects/writethedocs-www).
+The repo is still in its early stages; feel free to contribute information that you might want to share with the community. To contribute to the Write the Docs website, famililarize yourself with the [Sphinx site generator](http://sphinx.pocoo.org/index.html).
+
+Run `make html` in the `docs` directory to generate a local version of the site in
+`docs/_build/html/`.
+
+The Write the Docs website is hosted on [Read the Docs](https://readthedocs.org/projects/writethedocs-www).
 
 We develop documentation on a `dev` branch, which is rendered at http://writethedocs-www.readthedocs.org/en/dev/.


### PR DESCRIPTION
I took a quick look at getting rid of all the warnings generated by `make html`, which I think would be helpful for people not very used to Sphinx/ReST.
- There are a lot of  `WARNING: document isn't included in any toctree`, which I can fix for `rst` files by adding `:orphan:` but not for md files. Should we think about changing 2015 md files to rst? It does not seem to be possible to configure the build to ignore certain types of warning. 
- Some missing images `WARNING: image file not readable` - easy to fix

Thoughts? 
