### PR TITLE
Add AutoStructify

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,11 +5,12 @@ import json
 import re
 
 from recommonmark.parser import CommonMarkParser
+from recommonmark.transform import AutoStructify
 import ablog
 
 
 exclude_patterns = [
-    '_build', 
+    '_build',
     'include',
 ]
 extensions = [
@@ -146,6 +147,11 @@ def rstjinja(app, docname, source):
 def setup(app):
     app.connect('html-page-context', on_page_context)
     app.connect("source-read", rstjinja)
+    app.add_config_value('recommonmark_config', {
+        'auto_toc_tree_section': 'Contents',
+        'enable_auto_doc_ref': True,
+    }, True)
+    app.add_transform(AutoStructify)
 
 # Output formats
 

--- a/docs/meetups/index.md
+++ b/docs/meetups/index.md
@@ -12,7 +12,7 @@ themselves vary. The main thread that brings people together is caring
 about great communication and users of their product.
 
 We invite you to join a meetup in your local community. If your local
-community isn't listed here, feel free to [start one](../meetups/starting.html) and let us know.
+community isn't listed here, feel free to [start one](starting.rst) and let us know.
 We'd be happy to promote it and list it here.
 
 ### Current Meetups: North America


### PR DESCRIPTION
This uses the recommonmark autostruct functionality to transform the links into proper doc references:

http://recommonmark.readthedocs.io/en/latest/auto_structify.html#configuring-autostructify
and http://recommonmark.readthedocs.io/en/latest/auto_structify.html#auto-doc-ref
